### PR TITLE
Add section about network ID format

### DIFF
--- a/docs/chain-naming-standard.md
+++ b/docs/chain-naming-standard.md
@@ -12,17 +12,17 @@ Where `<networkId>` is the value of the field that is written inside the
 
 Please note that not using a valid name for the specification file will result into it being discarded.
 
-## Chain ID format
+## Network ID format
 
-A chain ID is a case-sensitive string in the format `^[a-zA-Z0-9_.-]{4,32}$`.
-When choosing a new chain ID, the following guildelines should be followed:
+A network ID is a case-sensitive string in the format `^[a-zA-Z0-9_.-]{4,32}$`.
+When choosing a new network ID, the following guildelines should be followed:
 
-1. Choose a chain ID that is long enough to be unique within the blockchain
+1. Choose a network ID that is long enough to be unique within the blockchain
    ecosystem.
-2. Choose a chain ID as short as possible to avoid unnecessary data.
-3. Choose a chain ID that is to some degree human readable and helps for basic
+2. Choose a network ID as short as possible to avoid unnecessary data.
+3. Choose a network ID that is to some degree human readable and helps for basic
    debugging.
 
-Some bad chain IDs are `ethereum` (violates 1.),
+Some bad network IDs are `ethereum` (violates 1.),
 `da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba` (violates 2.
 and 3.). Better alternatives are `ethereum-eip155-3` and `lisk-da3ed6a454`.

--- a/docs/chain-naming-standard.md
+++ b/docs/chain-naming-standard.md
@@ -11,3 +11,18 @@ Where `<networkId>` is the value of the field that is written inside the
 [chain specification file](/docs/chain-specification-standard.md) that you are submitting.
 
 Please note that not using a valid name for the specification file will result into it being discarded.
+
+## Chain ID format
+
+A chain ID is a case-sensitive string in the format `^[a-zA-Z0-9_.-]{4,32}$`.
+When choosing a new chain ID, the following guildelines should be followed:
+
+1. Choose a chain ID that is long enough to be unique within the blockchain
+   ecosystem.
+2. Choose a chain ID as short as possible to avoid unnecessary data.
+3. Choose a chain ID that is to some degree human readable and helps for basic
+   debugging.
+
+Some bad chain IDs are `ethereum` (violates 1.),
+`da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba` (violates 2.
+and 3.). Better alternatives are `ethereum-eip155-3` and `lisk-da3ed6a454`.


### PR DESCRIPTION
Will be updated once https://github.com/interchain-registry/interchain-registry/issues/12 is resolved.

Open questions:
1. Is 32 characters enough?
2. Do we want to allow upper case characters?
3. What are your feelings about changing `eip155-x` to `ethereum-eip155-x` and trying to start all chain IDs with the ecosystem (e.g. `cosmos-hub2`, `ethereum-eip155-3`, `iov-lovenet`, `lisk-da3ed6a454`).